### PR TITLE
Fix Lambda concurrency metric method for unit tests

### DIFF
--- a/python/apigw-http-api-lambda-dynamodb-python-cdk/stacks/apigw_http_api_lambda_dynamodb_python_cdk_stack.py
+++ b/python/apigw-http-api-lambda-dynamodb-python-cdk/stacks/apigw_http_api_lambda_dynamodb_python_cdk_stack.py
@@ -114,7 +114,7 @@ class ApigwHttpApiLambdaDynamodbPythonCdkStack(Stack):
         cloudwatch.Alarm(
             self,
             "LambdaConcurrencyAlarm",
-            metric=api_hanlder.metric_concurrent_executions(),
+            metric=api_hanlder.metric("ConcurrentExecutions"),
             threshold=80,
             evaluation_periods=2,
             alarm_description="Alert when Lambda concurrency exceeds 80% of reserved limit",


### PR DESCRIPTION
## Summary

This PR fixes a unit test failure caused by using an incorrect Lambda metric method. The `metric_concurrent_executions()` method doesn't exist in the CDK version being used.

## Changes Made

- Changed from `api_hanlder.metric_concurrent_executions()` to `api_hanlder.metric("ConcurrentExecutions")`
- Uses the generic `metric()` method with the CloudWatch metric name as a string parameter
- Maintains the same functionality for monitoring Lambda concurrent executions

## Testing

Unit tests now pass successfully:
```bash
pytest tests/ -v
```

## Files Modified

- `python/apigw-http-api-lambda-dynamodb-python-cdk/stacks/apigw_http_api_lambda_dynamodb_python_cdk_stack.py` - Fixed metric method call